### PR TITLE
Clarified oak tree gen

### DIFF
--- a/src/main/java/us/timinc/jsonifycraft/json/behavior/GrowTreeDescription.java
+++ b/src/main/java/us/timinc/jsonifycraft/json/behavior/GrowTreeDescription.java
@@ -14,6 +14,7 @@ public class GrowTreeDescription extends WorldBehaviorDescription {
 	public String log;
 	public int minHeight = 5;
 	public int maxHeight = 8;
+	public int bonusHeight = 0;
 	public boolean vines = false;
 	public String treeType;
 	public boolean growFromSapling = true;
@@ -37,7 +38,6 @@ public class GrowTreeDescription extends WorldBehaviorDescription {
 					.getConstructor(Boolean.class, GrowTreeDescription.class).newInstance(true, this);
 		} catch (InstantiationException | IllegalAccessException | IllegalArgumentException | InvocationTargetException
 				| NoSuchMethodException | SecurityException e) {
-			// TODO Auto-generated catch block
 			e.printStackTrace();
 		}
 

--- a/src/main/java/us/timinc/mcutil/Registries.java
+++ b/src/main/java/us/timinc/mcutil/Registries.java
@@ -764,6 +764,7 @@ public class Registries {
 
 	private void registerDefaultTreeGenerators() {
 		registerTreeGenerator("oak", TreeGenOak.class);
+		registerTreeGenerator("birch", TreeGenOak.class);
 		registerTreeGenerator("spruce", TreeGenPine.class);
 	}
 }


### PR DESCRIPTION
* Added a bonus height similar to birch tree gen.
* Added birch as a valid value for growtree.treeType. It points to the oak generator because they're the same thing.
* Added vine generation.
* Clarified internal variable names.
* Modified leaf span to generate leaves on maxHeight - minHeight levels below treeHeight, but only on levels where the calculated radius doesn't exceed 4. Accounts for huge trees.
* Randomness was removed from leaf generation. It looks cool on vanilla, but doesn't work well beyond a leaf span of 2.
* Leaves generate in a circular radius around the trunk, rather than a square radius. Might change this.